### PR TITLE
test: add component and page coverage

### DIFF
--- a/src/components/ControlPanel/ControlPanel.test.tsx
+++ b/src/components/ControlPanel/ControlPanel.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { TableProvider } from '../../context/TableContext';
+import ControlPanel from './ControlPanel';
+
+describe('ControlPanel', () => {
+  it('renders controls and edits table cells', () => {
+    render(
+      <TableProvider>
+        <ControlPanel />
+      </TableProvider>,
+    );
+
+    const removeColumn = screen.getByRole('button', { name: /Remove Column/ }) as HTMLButtonElement;
+    const removeRow = screen.getByRole('button', { name: /Remove Row/ }) as HTMLButtonElement;
+    expect(removeColumn.disabled).toBe(true);
+    expect(removeRow.disabled).toBe(true);
+
+    fireEvent.click(screen.getByRole('button', { name: /Add Column/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Add Row/ }));
+
+    const inputs = screen.getAllByRole('textbox') as HTMLInputElement[];
+    expect(inputs).toHaveLength(4);
+    fireEvent.change(inputs[3], { target: { value: 'bottom right' } });
+    expect(inputs[3].value).toBe('bottom right');
+
+    expect(removeColumn.disabled).toBe(false);
+    expect(removeRow.disabled).toBe(false);
+
+    fireEvent.click(screen.getByRole('button', { name: /Delete All Items/ }));
+    expect((screen.getAllByRole('textbox') as HTMLInputElement[])[3].value).toBe('');
+
+    fireEvent.click(removeColumn);
+    fireEvent.click(removeRow);
+    expect(screen.getAllByRole('textbox')).toHaveLength(1);
+
+    fireEvent.click(screen.getByRole('button', { name: /Add Column/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Reset Table/ }));
+    expect(screen.getAllByRole('textbox')).toHaveLength(1);
+  });
+});

--- a/src/components/ControlPanel/Output/Output.test.tsx
+++ b/src/components/ControlPanel/Output/Output.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { TableProvider } from '../../../context/TableContext';
+import Output from './Output';
+
+vi.mock('react-copy-to-clipboard', () => ({
+  default: ({
+    children,
+    onCopy,
+  }: {
+    children: React.ReactElement<{ onClick?: () => void }>;
+    onCopy?: () => void;
+  }) => React.cloneElement(children, { onClick: onCopy }),
+}));
+
+describe('Output', () => {
+  it('renders table HTML and copy state', () => {
+    render(
+      <TableProvider>
+        <Output />
+      </TableProvider>,
+    );
+
+    expect(screen.getByText(/<table>/).textContent).toContain('<td></td>');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy to Clipboard' }));
+    expect(screen.getByRole('button', { name: 'Copied' })).toBeTruthy();
+  });
+});

--- a/src/components/components.test.tsx
+++ b/src/components/components.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import Button from './Button';
+import Footer from './Footer';
+import Header from './Header';
+import SwitchTableForm from './SwitchTableForm';
+import Toggle from './Toggle';
+
+describe('components', () => {
+  it('renders and clicks a button', () => {
+    const onClick = vi.fn();
+
+    render(<Button onClick={onClick}>Save</Button>);
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables a button when isOne is true', () => {
+    render(<Button isOne>Disabled</Button>);
+
+    expect((screen.getByRole('button', { name: 'Disabled' }) as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+  });
+
+  it('renders and toggles the switch', () => {
+    const onClick = vi.fn();
+
+    render(<Toggle checked={false} onClick={onClick} />);
+    const checkbox = screen.getByRole('checkbox') as HTMLInputElement;
+    fireEvent.click(checkbox);
+
+    expect(checkbox.checked).toBe(false);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the table mode switch', () => {
+    const onClick = vi.fn();
+
+    render(<SwitchTableForm isPreview={true} onClick={onClick} />);
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    expect(screen.getByText('Edit')).toBeTruthy();
+    expect(screen.getByText('Preview')).toBeTruthy();
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders header navigation', () => {
+    render(
+      <MemoryRouter>
+        <Header />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('link', { name: 'HTML Table Creator' }).getAttribute('href')).toBe('/');
+  });
+
+  it('renders footer links', () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    render(
+      <MemoryRouter>
+        <Footer />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('link', { name: /Contact/ }).getAttribute('href')).toBe('/contact');
+    expect(screen.getByRole('link', { name: /GitHub/ }).getAttribute('href')).toBe(
+      'https://github.com/Kudoas/html-table-creator',
+    );
+    expect(screen.getByRole('link', { name: /What is <table>\?/ }).getAttribute('href')).toBe(
+      'https://developer.mozilla.org/ja/docs/Web/HTML/Element/table',
+    );
+    expect(screen.getByRole('link', { name: /kudoa/ }).getAttribute('href')).toBe(
+      'https://twitter.com/kudoadd',
+    );
+    expect(consoleSpy).toHaveBeenCalledWith('footer');
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/pages/Contact.test.tsx
+++ b/src/pages/Contact.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import Contact from './Contact';
+
+describe('Contact', () => {
+  it('renders and enables submit after message input', () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    render(
+      <MemoryRouter>
+        <Contact />
+      </MemoryRouter>,
+    );
+
+    const nameInput = screen.getByLabelText(/Your Name/) as HTMLInputElement;
+    const emailInput = screen.getByLabelText(/Your Email/) as HTMLInputElement;
+    const messageInput = screen.getByLabelText(/Message/) as HTMLTextAreaElement;
+    const submit = screen.getByRole('button', { name: 'Send' }) as HTMLButtonElement;
+
+    expect(submit.disabled).toBe(true);
+
+    fireEvent.change(nameInput, { target: { value: 'Kudoa' } });
+    fireEvent.change(emailInput, { target: { value: 'kudoa@example.com' } });
+    fireEvent.change(messageInput, { target: { value: 'Hello' } });
+
+    expect(nameInput.value).toBe('Kudoa');
+    expect(emailInput.value).toBe('kudoa@example.com');
+    expect(messageInput.value).toBe('Hello');
+    expect(submit.disabled).toBe(false);
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/pages/Home.test.tsx
+++ b/src/pages/Home.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import Home from './Home';
+
+const hotkeyMock = vi.hoisted(() => ({
+  callback: undefined as
+    | ((event: { preventDefault: () => void }, handler: unknown) => void)
+    | undefined,
+}));
+
+vi.mock('../utils/hotkeys', () => ({
+  hotkeyHandler: vi.fn(
+    (
+      _command: string,
+      callback: (event: { preventDefault: () => void }, handler: unknown) => void,
+    ) => {
+      hotkeyMock.callback = callback;
+    },
+  ),
+}));
+
+describe('Home', () => {
+  it('toggles between edit and preview modes', () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    render(
+      <MemoryRouter>
+        <Home isPreview={false} onClick={() => {}} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('Create Your Table')).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Add Column/ })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(screen.getByRole('button', { name: 'Copy to Clipboard' })).toBeTruthy();
+
+    const preventDefault = vi.fn();
+    act(() => {
+      hotkeyMock.callback?.({ preventDefault }, {});
+    });
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('button', { name: /Add Column/ })).toBeTruthy();
+
+    consoleSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

- Add React Testing Library coverage for shared components, ControlPanel, Output, Contact, and Home.
- Exercise table editing, preview toggling, copy state, footer/header links, and contact form interactions.
- Bring components and pages coverage to 100% while keeping the existing coverage configuration unchanged.

## Impact

The main UI surfaces now have regression coverage for render and interaction behavior. Overall coverage is now 95.55% statements, 100% branches, 93.61% functions, and 95.45% lines.

## Validation

- pnpm dlx prettier@3.8.3 --write src/components/components.test.tsx src/components/ControlPanel/ControlPanel.test.tsx src/components/ControlPanel/Output/Output.test.tsx src/pages/Contact.test.tsx src/pages/Home.test.tsx
- pnpm test
- pnpm test:coverage
- pnpm build

pnpm build still reports the existing webpack bundle size warnings only.