### PR TITLE
feat: Persist table state

### DIFF
--- a/src/hooks/useProvideTable.test.tsx
+++ b/src/hooks/useProvideTable.test.tsx
@@ -6,11 +6,64 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import { renderHook, act } from '@testing-library/react-hooks';
 
-import { useProvideTable } from './useProvideTable';
+import { TABLE_STORAGE_KEY, useProvideTable } from './useProvideTable';
 
 describe('useNewTable', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
   it('initial value', () => {
     const { result } = renderHook(() => useProvideTable());
+    expect(result.current.state).toStrictEqual([['']]);
+  });
+
+  it('restores table from localStorage', () => {
+    window.localStorage.setItem(
+      TABLE_STORAGE_KEY,
+      JSON.stringify([
+        ['Name', 'Age'],
+        ['Ada', '36'],
+      ]),
+    );
+
+    const { result } = renderHook(() => useProvideTable());
+
+    expect(result.current.state).toStrictEqual([
+      ['Name', 'Age'],
+      ['Ada', '36'],
+    ]);
+  });
+
+  it('ignores invalid localStorage table state', () => {
+    window.localStorage.setItem(TABLE_STORAGE_KEY, JSON.stringify([['Name'], [123]]));
+
+    const { result } = renderHook(() => useProvideTable());
+
+    expect(result.current.state).toStrictEqual([['']]);
+  });
+
+  it('ignores empty localStorage table state', () => {
+    window.localStorage.setItem(TABLE_STORAGE_KEY, JSON.stringify([]));
+
+    const { result } = renderHook(() => useProvideTable());
+
+    expect(result.current.state).toStrictEqual([['']]);
+  });
+
+  it('ignores empty row localStorage table state', () => {
+    window.localStorage.setItem(TABLE_STORAGE_KEY, JSON.stringify([[]]));
+
+    const { result } = renderHook(() => useProvideTable());
+
+    expect(result.current.state).toStrictEqual([['']]);
+  });
+
+  it('ignores broken localStorage table state', () => {
+    window.localStorage.setItem(TABLE_STORAGE_KEY, '{');
+
+    const { result } = renderHook(() => useProvideTable());
+
     expect(result.current.state).toStrictEqual([['']]);
   });
 
@@ -37,6 +90,20 @@ describe('useNewTable', () => {
       result.current.actions.addColumn();
     });
     expect(result.current.state).toStrictEqual([['', '']]);
+  });
+
+  it('stores table updates in localStorage', () => {
+    const { result } = renderHook(() => useProvideTable());
+
+    act(() => {
+      result.current.actions.addColumn();
+      result.current.actions.addRow();
+    });
+
+    expect(JSON.parse(window.localStorage.getItem(TABLE_STORAGE_KEY)!)).toStrictEqual([
+      ['', ''],
+      ['', ''],
+    ]);
   });
 
   it('remove column', () => {

--- a/src/hooks/useProvideTable.tsx
+++ b/src/hooks/useProvideTable.tsx
@@ -1,7 +1,51 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
+
+export const TABLE_STORAGE_KEY = 'html-table-creator:table-state';
+
+const createInitialTableState = (): string[][] => [['']];
+
+const isTableState = (value: unknown): value is string[][] => {
+  if (!Array.isArray(value) || value.length === 0 || !Array.isArray(value[0])) {
+    return false;
+  }
+
+  const columnLength = value[0].length;
+  if (columnLength === 0) {
+    return false;
+  }
+
+  return value.every(
+    (row) =>
+      Array.isArray(row) &&
+      row.length === columnLength &&
+      row.every((cell) => typeof cell === 'string'),
+  );
+};
+
+const loadTableState = (): string[][] => {
+  try {
+    const storedState = window.localStorage.getItem(TABLE_STORAGE_KEY);
+    if (!storedState) {
+      return createInitialTableState();
+    }
+
+    const parsedState = JSON.parse(storedState);
+    return isTableState(parsedState) ? parsedState : createInitialTableState();
+  } catch {
+    return createInitialTableState();
+  }
+};
 
 export const useProvideTable = () => {
-  const [state, setState] = useState([['']]);
+  const [state, setState] = useState<string[][]>(loadTableState);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(TABLE_STORAGE_KEY, JSON.stringify(state));
+    } catch {
+      // Ignore storage failures so table editing still works.
+    }
+  }, [state]);
 
   const onChange = useCallback(
     (e: React.FormEvent<HTMLInputElement>, column: number, row: number) => {
@@ -50,7 +94,7 @@ export const useProvideTable = () => {
   }, [state]);
 
   const reset = useCallback(() => {
-    setState([['']]);
+    setState(createInitialTableState());
   }, [state]);
 
   return {


### PR DESCRIPTION
## Summary

- Persist the table state to localStorage whenever it changes.
- Restore the saved table state on the next app load so users can resume work.
- Fall back to the initial one-cell table when saved data is missing or invalid.

## Validation

- pnpm test
- pnpm exec tsc --noEmit