### PR TITLE
feat: Add direct row and column table controls

### DIFF
--- a/docs/row-column-indexed-operations.md
+++ b/docs/row-column-indexed-operations.md
@@ -1,0 +1,125 @@
+# 行・列を直接指定して追加・削除するUI設計
+
+## 背景
+
+現在の行列操作は、追加・削除対象が一番右の列または一番下の行に固定されていた。
+
+これを、テーブル上で対象位置を直接選び、任意の行・列を追加・削除できるUIに変更する。
+
+## 方針
+
+select で行番号・列番号を選ぶUIではなく、テーブル本体の上と左に操作ボタンを配置する。
+
+- 列操作はテーブル上部に置く
+- 行操作はテーブル左側に置く
+- `+` は行・列の挿入
+- `-` は対象行・対象列の削除
+
+ユーザーが操作したい位置の近くにボタンを置くことで、番号指定より直感的にする。
+
+## 操作API
+
+`useProvideTable` に以下の action を追加する。
+
+```ts
+type InsertPosition = 'before' | 'after';
+
+addRowAt(rowIndex: number, position: InsertPosition): void;
+removeRowAt(rowIndex: number): void;
+
+addColumnAt(columnIndex: number, position: InsertPosition): void;
+removeColumnAt(columnIndex: number): void;
+```
+
+既存の末尾操作APIは互換性のため残す。
+
+- `addRow`
+- `removeRow`
+- `addColumn`
+- `removeColumn`
+
+## UI設計
+
+### 列操作
+
+テーブル上部に、列の挿入・削除ボタンを表示する。
+
+```text
+      +      -      +      -      +
+           [ A ]         [ B ]
+```
+
+- `+` は列と列の間、または端に配置する
+- `-` は対象列の上に配置する
+- `Add column before 1`
+- `Add column after N`
+- `Remove column N`
+
+### 行操作
+
+テーブル左側に、行の挿入・削除ボタンを表示する。
+
+```text
+  +
+  -   [ A ] [ B ]
+  +
+  -   [ C ] [ D ]
+  +
+```
+
+- `+` は行と行の間、または端に配置する
+- `-` は対象行の左に配置する
+- `Add row before 1`
+- `Add row after N`
+- `Remove row N`
+
+## disabled 条件
+
+削除ボタンは以下の場合に disabled にする。
+
+- 行数が `1` のとき、行削除ボタンを disabled
+- 列数が `1` のとき、列削除ボタンを disabled
+
+## 実装対象
+
+### `src/hooks/useProvideTable.tsx`
+
+指定行・指定列に対する追加・削除 action を追加する。
+
+配列更新は浅いコピーの直接変更ではなく、行配列もコピーして immutable に更新する。
+
+### `src/context/TableContext.tsx`
+
+新しい action を `TableContextProps` と provider value に追加する。
+
+### `src/components/ControlPanel/ControlPanel.tsx`
+
+`useTable()` から新しい action を受け取り、`TableForm` に渡す。
+
+### `src/components/ControlPanel/TableForm/TableForm.tsx`
+
+テーブル入力欄と同じ場所に、上部の列操作ボタンと左側の行操作ボタンを描画する。
+
+### `src/components/ControlPanel/ControlButtons/ControlButtons.tsx`
+
+全体操作だけを残す。
+
+- `Delete All Items`
+- `Reset Table`
+
+## テスト方針
+
+### `src/hooks/useProvideTable.test.tsx`
+
+- 指定行の前後に行を追加できる
+- 指定行を削除できる
+- 1行だけのとき行削除しても壊れない
+- 指定列の前後に列を追加できる
+- 指定列を削除できる
+- 1列だけのとき列削除しても壊れない
+
+### `src/components/ControlPanel/ControlPanel.test.tsx`
+
+- 左側のボタンから行を追加・削除できる
+- 上部のボタンから列を追加・削除できる
+- 1行・1列だけの場合、削除ボタンが disabled になる

--- a/src/components/ControlPanel/ControlButtons/ControlButtons.tsx
+++ b/src/components/ControlPanel/ControlButtons/ControlButtons.tsx
@@ -4,46 +4,22 @@ import styled from '@emotion/styled';
 import Button from '../../Button';
 
 type Props = {
-  state: string[][];
-  addColumn: () => void;
-  removeColumn: () => void;
-  addRow: () => void;
-  removeRow: () => void;
   deleteAllItems: () => void;
   reset: () => void;
 };
 
 const Component: React.FCX<Props> = ({
   className,
-  state,
-  addColumn,
-  removeColumn,
-  addRow,
-  removeRow,
   deleteAllItems,
   reset,
 }) => (
   <div className={className}>
-    <div>
-      <Button onClick={addColumn}>
-        Add Column <i className="fas fa-plus"></i>
-      </Button>
-      <Button onClick={addRow}>
-        Add Row <i className="fas fa-plus"></i>
-      </Button>
-      <Button onClick={removeColumn} isOne={state[0].length <= 1}>
-        Remove Column <i className="fas fa-trash-alt"></i>
-      </Button>
-      <Button onClick={removeRow} isOne={state.length <= 1}>
-        Remove Row <i className="fas fa-trash-alt"></i>
-      </Button>
-      <Button onClick={deleteAllItems}>
-        Delete All Items <i className="fas fa-trash-alt"></i>
-      </Button>
-      <Button onClick={reset}>
-        Reset Table <i className="fas fa-undo"></i>
-      </Button>
-    </div>
+    <Button onClick={deleteAllItems}>
+      Delete All Items <i className="fas fa-trash-alt"></i>
+    </Button>
+    <Button onClick={reset}>
+      Reset Table <i className="fas fa-undo"></i>
+    </Button>
   </div>
 );
 

--- a/src/components/ControlPanel/ControlPanel.test.tsx
+++ b/src/components/ControlPanel/ControlPanel.test.tsx
@@ -5,6 +5,10 @@ import { TableProvider } from '../../context/TableContext';
 import ControlPanel from './ControlPanel';
 
 describe('ControlPanel', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
   it('renders controls and edits table cells', () => {
     render(
       <TableProvider>
@@ -12,13 +16,15 @@ describe('ControlPanel', () => {
       </TableProvider>,
     );
 
-    const removeColumn = screen.getByRole('button', { name: /Remove Column/ }) as HTMLButtonElement;
-    const removeRow = screen.getByRole('button', { name: /Remove Row/ }) as HTMLButtonElement;
+    const removeColumn = screen.getByRole('button', {
+      name: 'Remove column 1',
+    }) as HTMLButtonElement;
+    const removeRow = screen.getByRole('button', { name: 'Remove row 1' }) as HTMLButtonElement;
     expect(removeColumn.disabled).toBe(true);
     expect(removeRow.disabled).toBe(true);
 
-    fireEvent.click(screen.getByRole('button', { name: /Add Column/ }));
-    fireEvent.click(screen.getByRole('button', { name: /Add Row/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Add column after 1' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Add row after 1' }));
 
     const inputs = screen.getAllByRole('textbox') as HTMLInputElement[];
     expect(inputs).toHaveLength(4);
@@ -35,8 +41,78 @@ describe('ControlPanel', () => {
     fireEvent.click(removeRow);
     expect(screen.getAllByRole('textbox')).toHaveLength(1);
 
-    fireEvent.click(screen.getByRole('button', { name: /Add Column/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Add column after 1' }));
     fireEvent.click(screen.getByRole('button', { name: /Reset Table/ }));
     expect(screen.getAllByRole('textbox')).toHaveLength(1);
+  });
+
+  it('adds and removes a row from the left controls', () => {
+    render(
+      <TableProvider>
+        <ControlPanel />
+      </TableProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add row after 1' }));
+
+    let inputs = screen.getAllByRole('textbox') as HTMLInputElement[];
+    fireEvent.change(inputs[0], { target: { value: 'row 1' } });
+    fireEvent.change(inputs[1], { target: { value: 'row 2' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add row before 2' }));
+
+    inputs = screen.getAllByRole('textbox') as HTMLInputElement[];
+    expect(inputs.map((input) => input.value)).toStrictEqual(['row 1', '', 'row 2']);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove row 2' }));
+
+    inputs = screen.getAllByRole('textbox') as HTMLInputElement[];
+    expect(inputs.map((input) => input.value)).toStrictEqual(['row 1', 'row 2']);
+  });
+
+  it('adds and removes a column from the top controls', () => {
+    render(
+      <TableProvider>
+        <ControlPanel />
+      </TableProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add column after 1' }));
+
+    let inputs = screen.getAllByRole('textbox') as HTMLInputElement[];
+    fireEvent.change(inputs[0], { target: { value: 'column 1' } });
+    fireEvent.change(inputs[1], { target: { value: 'column 2' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add column before 2' }));
+
+    inputs = screen.getAllByRole('textbox') as HTMLInputElement[];
+    expect(inputs.map((input) => input.value)).toStrictEqual(['column 1', '', 'column 2']);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove column 2' }));
+
+    inputs = screen.getAllByRole('textbox') as HTMLInputElement[];
+    expect(inputs.map((input) => input.value)).toStrictEqual(['column 1', 'column 2']);
+  });
+
+  it('disables row and column remove buttons when there is one item', () => {
+    render(
+      <TableProvider>
+        <ControlPanel />
+      </TableProvider>,
+    );
+
+    const removeRow = screen.getByRole('button', { name: 'Remove row 1' }) as HTMLButtonElement;
+    const removeColumn = screen.getByRole('button', {
+      name: 'Remove column 1',
+    }) as HTMLButtonElement;
+
+    expect(removeRow.disabled).toBe(true);
+    expect(removeColumn.disabled).toBe(true);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add row after 1' }));
+    expect(removeRow.disabled).toBe(false);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add column after 1' }));
+    expect(removeColumn.disabled).toBe(false);
   });
 });

--- a/src/components/ControlPanel/ControlPanel.tsx
+++ b/src/components/ControlPanel/ControlPanel.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 
 import { generateTableId } from '../../utils/generateTableId';
+import { type InsertPosition } from '../../hooks/useProvideTable';
 import { useTable } from '../../hooks/useTable';
 import ControlButtons from './ControlButtons/ControlButtons';
 import TableForm from './TableForm/TableForm';
@@ -9,10 +10,10 @@ import TableForm from './TableForm/TableForm';
 type Props = {
   state: string[][];
   onChange: (e: React.FormEvent<HTMLInputElement>, column: number, row: number) => void;
-  addColumn: () => void;
-  removeColumn: () => void;
-  addRow: () => void;
-  removeRow: () => void;
+  addColumnAt: (columnIndex: number, position: InsertPosition) => void;
+  removeColumnAt: (columnIndex: number) => void;
+  addRowAt: (rowIndex: number, position: InsertPosition) => void;
+  removeRowAt: (rowIndex: number) => void;
   deleteAllItems: () => void;
   reset: () => void;
 };
@@ -21,24 +22,24 @@ const Component: React.FCX<Props> = ({
   state,
   className,
   onChange,
-  addColumn,
-  removeColumn,
-  addRow,
-  removeRow,
+  addColumnAt,
+  removeColumnAt,
+  addRowAt,
+  removeRowAt,
   deleteAllItems,
   reset,
 }) => (
   <div className={className}>
-    <ControlButtons
+    <ControlButtons deleteAllItems={deleteAllItems} reset={reset} />
+    <TableForm
+      tableKeys={generateTableId(state)}
+      onChange={onChange}
       state={state}
-      addColumn={addColumn}
-      removeColumn={removeColumn}
-      addRow={addRow}
-      removeRow={removeRow}
-      deleteAllItems={deleteAllItems}
-      reset={reset}
+      addColumnAt={addColumnAt}
+      removeColumnAt={removeColumnAt}
+      addRowAt={addRowAt}
+      removeRowAt={removeRowAt}
     />
-    <TableForm tableKeys={generateTableId(state)} onChange={onChange} state={state} />
   </div>
 );
 
@@ -47,17 +48,25 @@ const StyledComponent = styled(Component)`
 `;
 
 const Container: React.FC = () => {
-  const { state, onChange, addColumn, removeColumn, addRow, removeRow, deleteAllItems, reset } =
-    useTable();
+  const {
+    state,
+    onChange,
+    addColumnAt,
+    removeColumnAt,
+    addRowAt,
+    removeRowAt,
+    deleteAllItems,
+    reset,
+  } = useTable();
 
   return (
     <StyledComponent
       state={state}
       onChange={onChange}
-      addColumn={addColumn}
-      removeColumn={removeColumn}
-      addRow={addRow}
-      removeRow={removeRow}
+      addColumnAt={addColumnAt}
+      removeColumnAt={removeColumnAt}
+      addRowAt={addRowAt}
+      removeRowAt={removeRowAt}
       deleteAllItems={deleteAllItems}
       reset={reset}
     />

--- a/src/components/ControlPanel/TableForm/TableForm.tsx
+++ b/src/components/ControlPanel/TableForm/TableForm.tsx
@@ -1,37 +1,302 @@
 import React from 'react';
 import styled from '@emotion/styled';
 
-import Column from './Column';
+import { type InsertPosition } from '../../../hooks/useProvideTable';
 
 type Props = {
   keys?: number[];
   state: string[][];
   tableKeys: number[][];
   onChange: (e: React.FormEvent<HTMLInputElement>, column: number, row: number) => void;
+  addColumnAt: (columnIndex: number, position: InsertPosition) => void;
+  removeColumnAt: (columnIndex: number) => void;
+  addRowAt: (rowIndex: number, position: InsertPosition) => void;
+  removeRowAt: (rowIndex: number) => void;
 };
 
-const Component: React.FCX<Props> = ({ className, keys, tableKeys, onChange, state }) => (
-  <div className={className}>
-    {keys.map((k) => (
-      <Column key={k} column={k} tableKeys={tableKeys} onChange={onChange} state={state} />
-    ))}
-  </div>
-);
+const Component: React.FCX<Props> = ({
+  className,
+  keys,
+  tableKeys,
+  onChange,
+  state,
+  addColumnAt,
+  removeColumnAt,
+  addRowAt,
+  removeRowAt,
+}) => {
+  const rowIndexes = keys ?? [];
+  const columnIndexes = tableKeys[0] ?? [];
+  const dataGridTemplate = `36px repeat(${columnIndexes.length}, var(--cell-width))`;
+
+  return (
+    <div className={className}>
+      <div className="table-editor">
+        <div className="column-controls" style={{ gridTemplateColumns: dataGridTemplate }}>
+          <div />
+          {columnIndexes.map((columnIndex) => (
+            <div className="column-control-cell" key={columnIndex}>
+              <button
+                type="button"
+                className="operation-button add-button column-add-button"
+                aria-label={`Add column before ${columnIndex + 1}`}
+                onClick={() => addColumnAt(columnIndex, 'before')}
+              >
+                +
+              </button>
+              <button
+                type="button"
+                className="operation-button remove-button"
+                aria-label={`Remove column ${columnIndex + 1}`}
+                disabled={state[0].length <= 1}
+                onClick={() => removeColumnAt(columnIndex)}
+              >
+                -
+              </button>
+            </div>
+          ))}
+          <button
+            type="button"
+            className="operation-button add-button column-add-button column-add-button-after"
+            aria-label={`Add column after ${columnIndexes.length}`}
+            onClick={() => addColumnAt(columnIndexes.length - 1, 'after')}
+          >
+            +
+          </button>
+        </div>
+        <div
+          className="column-guides"
+          aria-hidden="true"
+          style={{ gridTemplateColumns: dataGridTemplate }}
+        >
+          <div />
+          {columnIndexes.map((columnIndex) => (
+            <div className="column-guide-cell" key={columnIndex} />
+          ))}
+        </div>
+
+        {rowIndexes.map((rowIndex) => (
+          <React.Fragment key={rowIndex}>
+            <div className="row-insert-line" style={{ gridTemplateColumns: dataGridTemplate }}>
+              <button
+                type="button"
+                className="operation-button add-button"
+                aria-label={`Add row before ${rowIndex + 1}`}
+                onClick={() => addRowAt(rowIndex, 'before')}
+              >
+                +
+              </button>
+              <div className="row-insert-guide" />
+            </div>
+            <div className="table-row" style={{ gridTemplateColumns: dataGridTemplate }}>
+              <button
+                type="button"
+                className="operation-button remove-button"
+                aria-label={`Remove row ${rowIndex + 1}`}
+                disabled={state.length <= 1}
+                onClick={() => removeRowAt(rowIndex)}
+              >
+                -
+              </button>
+              {columnIndexes.map((columnIndex) => (
+                <input
+                  key={columnIndex}
+                  type="text"
+                  value={state[rowIndex][columnIndex]}
+                  onChange={(e) => onChange(e, rowIndex, columnIndex)}
+                />
+              ))}
+            </div>
+          </React.Fragment>
+        ))}
+
+        <div className="row-insert-line" style={{ gridTemplateColumns: dataGridTemplate }}>
+          <button
+            type="button"
+            className="operation-button add-button"
+            aria-label={`Add row after ${rowIndexes.length}`}
+            onClick={() => addRowAt(rowIndexes.length - 1, 'after')}
+          >
+            +
+          </button>
+          <div className="row-insert-guide" />
+        </div>
+      </div>
+    </div>
+  );
+};
 
 const StyledComponent = styled(Component)`
-  > {
-    text-align: center;
-    margin: 10px;
+  --cell-width: 170px;
+
+  overflow-x: auto;
+  padding: 10px;
+  text-align: center;
+
+  .table-editor {
+    display: inline-block;
+    min-width: max-content;
+    position: relative;
+  }
+
+  .column-controls,
+  .column-guides,
+  .table-row,
+  .row-insert-line {
+    align-items: center;
+    display: grid;
+    gap: 6px;
+    justify-content: center;
+  }
+
+  .column-controls {
+    margin-bottom: 2px;
+    position: relative;
+    z-index: 2;
+  }
+
+  .column-control-cell {
+    align-items: center;
+    display: flex;
+    justify-content: center;
+    position: relative;
+  }
+
+  .column-guides {
+    bottom: 0;
+    left: 0;
+    pointer-events: none;
+    position: absolute;
+    right: 0;
+    top: 26px;
+    z-index: 0;
+  }
+
+  .column-guide-cell {
+    height: 100%;
+    position: relative;
+  }
+
+  .column-guide-cell::before {
+    border-left: 1px dashed rgba(0, 0, 0, 0.12);
+    bottom: 0;
+    content: '';
+    left: -3px;
+    position: absolute;
+    top: 0;
+  }
+
+  .column-guide-cell:last-child::after {
+    border-left: 1px dashed rgba(0, 0, 0, 0.12);
+    bottom: 0;
+    content: '';
+    position: absolute;
+    right: -3px;
+    top: 0;
+  }
+
+  .row-insert-line {
+    min-height: 24px;
+    position: relative;
+    z-index: 1;
+  }
+
+  .row-insert-guide {
+    border-top: 1px dashed rgba(0, 0, 0, 0.12);
+    grid-column: 2 / -1;
+    height: 1px;
+  }
+
+  .table-row {
+    margin: 2px 0;
+    position: relative;
+    z-index: 1;
+  }
+
+  input {
+    background-color: #e0e5ec;
+    border: 0;
+    border-radius: 5px;
+    box-shadow: 2px 2px 10px #ffffff, -2px -2px 10px #a3b1c6;
+    box-sizing: border-box;
+    padding: 8px;
+    width: var(--cell-width);
+  }
+
+  .operation-button {
+    align-items: center;
+    background-color: #e0e5ec;
+    border: 0;
+    border-radius: 50%;
+    box-shadow: 1px 1px 5px #a3b1c6, -1px -1px 5px #ffffff;
+    color: black;
+    cursor: pointer;
+    display: inline-flex;
+    font-weight: bold;
+    height: 24px;
+    justify-content: center;
+    line-height: 1;
+    margin: 0 auto;
+    width: 24px;
+  }
+
+  .operation-button:hover {
+    color: white;
+  }
+
+  .operation-button:disabled {
+    background: #ccc;
+    border: #ccc;
+    box-shadow: 1px 1px 5px #ffffff, -1px -1px 5px #a3b1c6;
+    color: #ffffff;
+    cursor: not-allowed;
+  }
+
+  .add-button {
+    font-size: 18px;
+  }
+
+  .remove-button {
+    font-size: 20px;
+  }
+
+  .column-add-button {
+    left: -15px;
+    position: absolute;
+  }
+
+  .column-add-button-after {
+    left: auto;
+    right: -15px;
   }
 `;
 
-const Container: React.FCX<Props> = ({ tableKeys, onChange, state }) => {
+const Container: React.FCX<Props> = ({
+  tableKeys,
+  onChange,
+  state,
+  addColumnAt,
+  removeColumnAt,
+  addRowAt,
+  removeRowAt,
+}) => {
   let keys = [];
   for (let i in tableKeys) {
     keys.push(Number(i));
   }
 
-  return <StyledComponent keys={keys} tableKeys={tableKeys} onChange={onChange} state={state} />;
+  return (
+    <StyledComponent
+      keys={keys}
+      tableKeys={tableKeys}
+      onChange={onChange}
+      state={state}
+      addColumnAt={addColumnAt}
+      removeColumnAt={removeColumnAt}
+      addRowAt={addRowAt}
+      removeRowAt={removeRowAt}
+    />
+  );
 };
 
 export default Container;

--- a/src/context/TableContext.tsx
+++ b/src/context/TableContext.tsx
@@ -1,13 +1,17 @@
 import React, { createContext } from 'react';
-import { useProvideTable } from '../hooks/useProvideTable';
+import { type InsertPosition, useProvideTable } from '../hooks/useProvideTable';
 
 export interface TableContextProps {
   state: string[][];
   onChange: (e: React.FormEvent<HTMLInputElement>, column: number, row: number) => void;
   addColumn: () => void;
+  addColumnAt: (columnIndex: number, position: InsertPosition) => void;
   removeColumn: () => void;
+  removeColumnAt: (columnIndex: number) => void;
   addRow: () => void;
+  addRowAt: (rowIndex: number, position: InsertPosition) => void;
   removeRow: () => void;
+  removeRowAt: (rowIndex: number) => void;
   deleteAllItems: () => void;
   reset: () => void;
 }
@@ -20,11 +24,36 @@ type Props = {
 
 export const TableProvider: React.FC<Props> = ({ children }) => {
   const { state, actions } = useProvideTable();
-  const { onChange, addColumn, removeColumn, addRow, removeRow, deleteAllItems, reset } = actions;
+  const {
+    onChange,
+    addColumn,
+    addColumnAt,
+    removeColumn,
+    removeColumnAt,
+    addRow,
+    addRowAt,
+    removeRow,
+    removeRowAt,
+    deleteAllItems,
+    reset,
+  } = actions;
 
   return (
     <TableContext.Provider
-      value={{ state, onChange, addColumn, removeColumn, addRow, removeRow, deleteAllItems, reset }}
+      value={{
+        state,
+        onChange,
+        addColumn,
+        addColumnAt,
+        removeColumn,
+        removeColumnAt,
+        addRow,
+        addRowAt,
+        removeRow,
+        removeRowAt,
+        deleteAllItems,
+        reset,
+      }}
     >
       {children}
     </TableContext.Provider>

--- a/src/hooks/useProvideTable.test.tsx
+++ b/src/hooks/useProvideTable.test.tsx
@@ -83,6 +83,67 @@ describe('useNewTable', () => {
     });
   });
 
+  it('add row before selected row', () => {
+    window.localStorage.setItem(
+      TABLE_STORAGE_KEY,
+      JSON.stringify([
+        ['row 1'],
+        ['row 2'],
+      ]),
+    );
+    const { result } = renderHook(() => useProvideTable());
+
+    act(() => {
+      result.current.actions.addRowAt(1, 'before');
+    });
+
+    expect(result.current.state).toStrictEqual([['row 1'], [''], ['row 2']]);
+  });
+
+  it('add row after selected row', () => {
+    window.localStorage.setItem(
+      TABLE_STORAGE_KEY,
+      JSON.stringify([
+        ['row 1'],
+        ['row 2'],
+      ]),
+    );
+    const { result } = renderHook(() => useProvideTable());
+
+    act(() => {
+      result.current.actions.addRowAt(0, 'after');
+    });
+
+    expect(result.current.state).toStrictEqual([['row 1'], [''], ['row 2']]);
+  });
+
+  it('remove selected row', () => {
+    window.localStorage.setItem(
+      TABLE_STORAGE_KEY,
+      JSON.stringify([
+        ['row 1'],
+        ['row 2'],
+      ]),
+    );
+    const { result } = renderHook(() => useProvideTable());
+
+    act(() => {
+      result.current.actions.removeRowAt(0);
+    });
+
+    expect(result.current.state).toStrictEqual([['row 2']]);
+  });
+
+  it('keeps at least one row when removing selected row', () => {
+    const { result } = renderHook(() => useProvideTable());
+
+    act(() => {
+      result.current.actions.removeRowAt(0);
+    });
+
+    expect(result.current.state).toStrictEqual([['']]);
+  });
+
   it('add column', () => {
     const { result } = renderHook(() => useProvideTable());
     act(() => {
@@ -111,6 +172,49 @@ describe('useNewTable', () => {
       result.current.actions.addColumn();
       result.current.actions.removeColumn();
     });
+    expect(result.current.state).toStrictEqual([['']]);
+  });
+
+  it('add column before selected column', () => {
+    window.localStorage.setItem(TABLE_STORAGE_KEY, JSON.stringify([['column 1', 'column 2']]));
+    const { result } = renderHook(() => useProvideTable());
+
+    act(() => {
+      result.current.actions.addColumnAt(1, 'before');
+    });
+
+    expect(result.current.state).toStrictEqual([['column 1', '', 'column 2']]);
+  });
+
+  it('add column after selected column', () => {
+    window.localStorage.setItem(TABLE_STORAGE_KEY, JSON.stringify([['column 1', 'column 2']]));
+    const { result } = renderHook(() => useProvideTable());
+
+    act(() => {
+      result.current.actions.addColumnAt(0, 'after');
+    });
+
+    expect(result.current.state).toStrictEqual([['column 1', '', 'column 2']]);
+  });
+
+  it('remove selected column', () => {
+    window.localStorage.setItem(TABLE_STORAGE_KEY, JSON.stringify([['column 1', 'column 2']]));
+    const { result } = renderHook(() => useProvideTable());
+
+    act(() => {
+      result.current.actions.removeColumnAt(0);
+    });
+
+    expect(result.current.state).toStrictEqual([['column 2']]);
+  });
+
+  it('keeps at least one column when removing selected column', () => {
+    const { result } = renderHook(() => useProvideTable());
+
+    act(() => {
+      result.current.actions.removeColumnAt(0);
+    });
+
     expect(result.current.state).toStrictEqual([['']]);
   });
 

--- a/src/hooks/useProvideTable.tsx
+++ b/src/hooks/useProvideTable.tsx
@@ -2,6 +2,8 @@ import React, { useState, useCallback, useEffect } from 'react';
 
 export const TABLE_STORAGE_KEY = 'html-table-creator:table-state';
 
+export type InsertPosition = 'before' | 'after';
+
 const createInitialTableState = (): string[][] => [['']];
 
 const isTableState = (value: unknown): value is string[][] => {
@@ -50,61 +52,102 @@ export const useProvideTable = () => {
   const onChange = useCallback(
     (e: React.FormEvent<HTMLInputElement>, column: number, row: number) => {
       const tableItem = e.currentTarget.value;
-      const updateState = [...state];
-      updateState[column][row] = tableItem;
-      setState(updateState);
+      setState((currentState) =>
+        currentState.map((currentRow, rowIndex) =>
+          rowIndex === column
+            ? currentRow.map((cell, columnIndex) => (columnIndex === row ? tableItem : cell))
+            : currentRow,
+        ),
+      );
     },
-    [state],
+    [],
   );
 
+  const addColumnAt = useCallback((columnIndex: number, position: InsertPosition) => {
+    setState((currentState) => {
+      const insertIndex = position === 'after' ? columnIndex + 1 : columnIndex;
+      const boundedInsertIndex = Math.max(0, Math.min(insertIndex, currentState[0].length));
+
+      return currentState.map((currentRow) => [
+        ...currentRow.slice(0, boundedInsertIndex),
+        '',
+        ...currentRow.slice(boundedInsertIndex),
+      ]);
+    });
+  }, []);
+
+  const removeColumnAt = useCallback((columnIndex: number) => {
+    setState((currentState) => {
+      if (currentState[0].length <= 1 || columnIndex < 0 || columnIndex >= currentState[0].length) {
+        return currentState;
+      }
+
+      return currentState.map((currentRow) =>
+        currentRow.filter((_, currentColumnIndex) => currentColumnIndex !== columnIndex),
+      );
+    });
+  }, []);
+
+  const addRowAt = useCallback((rowIndex: number, position: InsertPosition) => {
+    setState((currentState) => {
+      const insertIndex = position === 'after' ? rowIndex + 1 : rowIndex;
+      const boundedInsertIndex = Math.max(0, Math.min(insertIndex, currentState.length));
+      const initRow = new Array(currentState[0].length).fill('');
+
+      return [
+        ...currentState.slice(0, boundedInsertIndex),
+        initRow,
+        ...currentState.slice(boundedInsertIndex),
+      ];
+    });
+  }, []);
+
+  const removeRowAt = useCallback((rowIndex: number) => {
+    setState((currentState) => {
+      if (currentState.length <= 1 || rowIndex < 0 || rowIndex >= currentState.length) {
+        return currentState;
+      }
+
+      return currentState.filter((_, currentRowIndex) => currentRowIndex !== rowIndex);
+    });
+  }, []);
+
   const addColumn = useCallback(() => {
-    let updateState = [...state];
-    for (const updateStateItem of updateState) {
-      updateStateItem.push('');
-    }
-    setState(updateState);
-  }, [state]);
+    addColumnAt(state[0].length - 1, 'after');
+  }, [addColumnAt, state]);
 
   const removeColumn = useCallback(() => {
-    let updateState = [...state];
-    for (const updateStateItem of updateState) {
-      updateStateItem.pop();
-    }
-    setState(updateState);
-  }, [state]);
+    removeColumnAt(state[0].length - 1);
+  }, [removeColumnAt, state]);
 
   const addRow = useCallback(() => {
-    let updateState = [...state];
-    const initRow = new Array(updateState[0].length).fill('');
-    updateState.push(initRow);
-    setState(updateState);
-  }, [state]);
+    addRowAt(state.length - 1, 'after');
+  }, [addRowAt, state]);
 
   const removeRow = useCallback(() => {
-    const updateState = [...state].slice(0, state.length - 1);
-    setState(updateState);
-  }, [state]);
+    removeRowAt(state.length - 1);
+  }, [removeRowAt, state]);
 
   const deleteAllItems = useCallback(() => {
-    let updateState = [...state];
-    for (const updateStateItem of updateState) {
-      updateStateItem.fill('');
-    }
-    setState(updateState);
-  }, [state]);
+    setState((currentState) => currentState.map((currentRow) => currentRow.map(() => '')));
+  }, []);
 
   const reset = useCallback(() => {
     setState(createInitialTableState());
-  }, [state]);
+  }, []);
 
   return {
     state,
     actions: {
       onChange,
       addColumn,
+      addColumnAt,
       removeColumn,
+      removeColumnAt,
       addRow,
+      addRowAt,
       removeRow,
+      removeRowAt,
       deleteAllItems,
       reset,
     },

--- a/src/pages/Home.test.tsx
+++ b/src/pages/Home.test.tsx
@@ -32,7 +32,7 @@ describe('Home', () => {
     );
 
     expect(screen.getByText('Create Your Table')).toBeTruthy();
-    expect(screen.getByRole('button', { name: /Add Column/ })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Add column after 1' })).toBeTruthy();
 
     fireEvent.click(screen.getByRole('checkbox'));
     expect(screen.getByRole('button', { name: 'Copy to Clipboard' })).toBeTruthy();
@@ -42,7 +42,7 @@ describe('Home', () => {
       hotkeyMock.callback?.({ preventDefault }, {});
     });
     expect(preventDefault).toHaveBeenCalledTimes(1);
-    expect(screen.getByRole('button', { name: /Add Column/ })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Add column after 1' })).toBeTruthy();
 
     consoleSpy.mockRestore();
   });


### PR DESCRIPTION
## Summary

- Add direct row and column insertion/removal controls around the table editor.
- Keep global controls focused on deleting cell contents and resetting the table.
- Add indexed table mutation actions and tests for row/column insertion and removal.
- Document the direct-control UI design in docs/row-column-indexed-operations.md.

## Validation

- pnpm test
- pnpm build
- Browser check on http://localhost:3030/ for the direct row/column controls and guide alignment.